### PR TITLE
Remove abstract preview from collapsed article cards

### DIFF
--- a/assets/js/database.js
+++ b/assets/js/database.js
@@ -245,10 +245,6 @@ function createCardElement(item, filterLabelsMap, infoLabelsMap) {
   if (item.venue) metaParts.push(escapeHTML(item.venue));
   const cardMeta = metaParts.join(" • ");
 
-  const abstractPreview = item.abstract
-    ? escapeHTML(truncateText(item.abstract, 220))
-    : "";
-
   const filterTags = FILTER_KEYS.map((key) =>
     createTagSection(filterLabelsMap[key], item[key])
   )
@@ -277,7 +273,6 @@ function createCardElement(item, filterLabelsMap, infoLabelsMap) {
     </div>
     <div class="card-title">${safeTitle}</div>
     ${filterTags ? `<div class="card-tags">${filterTags}</div>` : ""}
-    ${abstractPreview ? `<p class="card-abstract">${abstractPreview}</p>` : ""}
     ${expandedDetails}
   `;
 


### PR DESCRIPTION
## Summary
- stop rendering abstract previews in the collapsed article cards so details only appear when expanded

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd58a75ea0832eb586ee124280450b