### PR TITLE
Add venue tag filtering to database view

### DIFF
--- a/assets/css/database.css
+++ b/assets/css/database.css
@@ -123,6 +123,64 @@ HERO SECTION
   z-index: -1;
 }
 
+.venue-filter-section {
+  margin-top: 15px;
+  padding: 10px 15px 15px;
+  background-color: rgba(211, 208, 203, 0.6);
+  border-radius: 8px;
+}
+
+.venue-filter-section[hidden] {
+  display: none;
+}
+
+.venue-filter-section h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 10px;
+  text-align: center;
+}
+
+.venue-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.venue-tag {
+  border: 1px solid var(--grey);
+  background-color: rgba(255, 255, 255, 0.9);
+  color: var(--grey);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  text-transform: none;
+}
+
+.venue-tag:hover {
+  border-color: var(--sienna);
+  color: var(--sienna);
+}
+
+.venue-tag:focus {
+  outline: 2px solid var(--sienna);
+  outline-offset: 2px;
+}
+
+.venue-tag--active {
+  background-color: var(--sienna);
+  border-color: var(--sienna);
+  color: var(--contrast-color);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+.venue-tag--inactive {
+  opacity: 0.6;
+}
+
 /* Each filter group */
 .filter-group {
   flex: 1;

--- a/database.html
+++ b/database.html
@@ -68,6 +68,10 @@
                 </button>
             </div>
             <section class="filters"></section>
+            <section class="venue-filter-section">
+                <h3>Venues</h3>
+                <div id="venue-tags" class="venue-tags" role="group" aria-label="Filter by venue"></div>
+            </section>
         </section>
 
         <!-- DATABASE CARDS TABLE -->


### PR DESCRIPTION
## Summary
- add a venue tag section below the standard filters so readers can toggle venues directly
- implement client-side logic to derive venues from the CSV and filter cards alongside existing controls
- style the new venue tag controls for active and inactive states

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dd5b991094832e9eb3e02b612e4c28