### PR TITLE
Convert venue chips to checkboxes and stabilize filter layout

### DIFF
--- a/assets/css/database.css
+++ b/assets/css/database.css
@@ -159,63 +159,7 @@ HERO SECTION
   width: 100%;
 }
 
-.venue-filter-section {
-  margin-top: 15px;
-  padding: 10px 15px 15px;
-  background-color: rgba(211, 208, 203, 0.6);
-  border-radius: 8px;
-}
-
-.venue-filter-section[hidden] {
-  display: none;
-}
-
-.venue-filter-section h3 {
-  font-size: 16px;
-  font-weight: 600;
-  margin-bottom: 10px;
-  text-align: center;
-}
-
-.venue-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  justify-content: center;
-}
-
-.venue-tag {
-  border: 1px solid var(--grey);
-  background-color: rgba(255, 255, 255, 0.9);
-  color: var(--grey);
-  border-radius: 999px;
-  padding: 6px 14px;
-  font-size: 14px;
-  cursor: pointer;
-  transition: all 0.2s ease-in-out;
-  text-transform: none;
-}
-
-.venue-tag:hover {
-  border-color: var(--sienna);
-  color: var(--sienna);
-}
-
-.venue-tag:focus {
-  outline: 2px solid var(--sienna);
-  outline-offset: 2px;
-}
-
-.venue-tag--active {
-  background-color: var(--sienna);
-  border-color: var(--sienna);
-  color: var(--contrast-color);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
-}
-
-.venue-tag--inactive {
-  opacity: 0.6;
-}
+/* Dedicated styles for venue tags removed in favor of shared checkbox styling */
 
 /* Each filter group */
 .filter-group {
@@ -320,6 +264,7 @@ HERO SECTION
   flex-direction: column;
   max-height: 150px;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 5px;
   border: 1px solid var(--grey);
   border-radius: 5px;
@@ -340,7 +285,10 @@ HERO SECTION
 .filter-options input[type="checkbox"] {
   width: 18px;
   height: 18px;
-  margin-right: 6px;
+  min-width: 18px;
+  min-height: 18px;
+  flex: 0 0 18px;
+  margin-right: 0;
   appearance: none;
   border: 0.5px solid var(--grey);
   border-radius: 3px;
@@ -349,6 +297,7 @@ HERO SECTION
   display: inline-block;
   position: relative;
   transition: all 0.2s ease-in-out;
+  box-sizing: border-box;
 }
 
 .filter-options label {
@@ -357,7 +306,15 @@ HERO SECTION
   font-size: 14px;
   color: var(--grey);
   cursor: pointer;
-  gap: 6px;
+  gap: 8px;
+}
+
+.filter-option-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 14px;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 .testing {
@@ -366,6 +323,7 @@ HERO SECTION
 }
 
 .filter-options .filter-count {
+  flex: 0 0 auto;
   font-weight: 300;
   color: var(--grey);
   font-size: 0.9em;
@@ -634,6 +592,14 @@ padding-bottom: 10px;
   color: var(--grey);
   margin: 0;
   padding: 0;
+  line-height: 1.4;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.card-meta-venue {
+  font-style: italic;
 }
 
 /* Centered & Styled Title */
@@ -642,7 +608,7 @@ padding-bottom: 10px;
   font-weight: 500;
   text-align: center;
   margin: 10px 0px;
-  line-height: 14px;
+  line-height: 1.35;
   color: var(--offblack);
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
@@ -661,6 +627,10 @@ padding-bottom: 10px;
 /*-------------------------------------------------------------------
   # DATABASE CARD TAG STYLES (SMALLER & CLEANER)
 -------------------------------------------------------------------*/
+
+.card-tags {
+  padding: 6px 8px;
+}
 
 .card-tags div {
   font-size: 12px;  /* Smaller font size for tag headings */
@@ -692,6 +662,7 @@ padding-bottom: 10px;
 .tag-container {
   display: flex;
   flex-wrap: wrap;
+  gap: 4px;
 }
 
 /* Individual Tags */

--- a/index.html
+++ b/index.html
@@ -71,10 +71,6 @@
                 <div class="filter-toggle-list" id="filter-toggle-list" role="group" aria-label="Filter categories"></div>
                 <div class="filter-card-grid" id="filter-card-grid"></div>
             </section>
-            <section class="venue-filter-section">
-                <h3>Venues</h3>
-                <div id="venue-tags" class="venue-tags" role="group" aria-label="Filter by venue"></div>
-            </section>
         </section>
 
         <!-- DATABASE CARDS TABLE -->


### PR DESCRIPTION
## Summary
- replace the venue tag buttons with checkbox options that plug into the existing filter toggles and counts
- enforce square checkbox dimensions and consistent spacing while dynamically shrinking long option labels to a single line
- add reusable text-fit helpers so filter labels stay legible as counts and viewport widths change

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ed9e23e39c832e8b0d2353b282cb00